### PR TITLE
Update ci.yml to upload coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,13 @@ jobs:
         python manage.py migrate
         coverage run manage.py test
         coverage report
+        coverage xml
+    - name: Publish tests to Code Climate
+      run: |
+        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+        chmod +x cc-test-reporter
+        ./cc-test-reporter format-coverage -t coverage.py coverage.xml
+        ./cc-test-reporter upload-coverage
+      env:
+        CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2020.2-Projeto-Kokama-Usuario&metric=alert_status)](https://sonarcloud.io/dashboard?id=fga-eps-mds_2020.2-Projeto-Kokama-Usuario)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/cb81887ef740b6d47c60/test_coverage)](https://codeclimate.com/github/fga-eps-mds/2020.2-Projeto-Kokama-Usuario/test_coverage)
 
 # 2020.2-Projeto-Kokama-Usuario
 


### PR DESCRIPTION
## Descrição 

Atualização do scritp de verificação dos testes para incluir upload para o Code Climate, gerando a badge de cobertura.

**Resolve parcialmente a issue [#186](https://github.com/fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/186).**

## Tarefas realizadas

- [x] Realizar upload do arquivo de report ao CodeClimate;
- [x] Apresentar a badge de cobertura.